### PR TITLE
Remove HL2 plugins from L4D2

### DIFF
--- a/containers/l4d2/server_entrypoint.sh
+++ b/containers/l4d2/server_entrypoint.sh
@@ -8,6 +8,16 @@ cp -r /fastdownload/l4d2 $STEAM_GAME_DIR/left4dead2/addons/
 # copy addonconfig as srcds install will overwrite
 cp $STEAM_GAME_DIR/addonconfig.cfg $STEAM_GAME_DIR/left4dead2/cfg/addonconfig.cfg
 
+# Delete plugins that the hl2 dockerfile has rudely installed
+rm $STEAM_GAME_DIR/left4dead2/addons/sourcemod/plugins/nextmap.smx
+rm $STEAM_GAME_DIR/left4dead2/addons/sourcemod/plugins/mapchooser.smx
+rm $STEAM_GAME_DIR/left4dead2/addons/sourcemod/plugins/rockthevote.smx
+rm $STEAM_GAME_DIR/left4dead2/addons/sourcemod/plugins/nominations.smx
+rm $STEAM_GAME_DIR/left4dead2/addons/sourcemod/plugins/overspray.smx
+rm $STEAM_GAME_DIR/left4dead2/addons/sourcemod/plugins/randomcycle.smx
+rm $STEAM_GAME_DIR/left4dead2/addons/sourcemod/plugins/reservedslots.smx
+rm $STEAM_GAME_DIR/left4dead2/addons/sourcemod/plugins/spraytrace.smx
+
 $STEAM_GAME_DIR/srcds_run \
     -game left4dead2 \
     +ip 0.0.0.0 \

--- a/containers/tf2/tf2.Dockerfile
+++ b/containers/tf2/tf2.Dockerfile
@@ -1,6 +1,6 @@
 FROM team-brh/hl2:latest
 
-# Link sourcmod directory
+# Link sourcemod directory
 RUN mkdir -p $STEAM_GAME_DIR/tf/ \
     && ln -s /steam/addons $STEAM_GAME_DIR/tf/addons
 


### PR DESCRIPTION
One of these was changing the map to random one between versus rounds. The other ones probably don't do anything good in L4D2.